### PR TITLE
Https patch

### DIFF
--- a/spidMetadataSigner.sh
+++ b/spidMetadataSigner.sh
@@ -74,7 +74,7 @@ echo -e "\n"
 # Download e installazione XmlSecTool 2.0.0
 if [ ! -d "xmlsectool-2.0.0" ]; then
     echo "Scaricamento XmlSecTool 2.0.0:"
-    curl -OJ http://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip
+    curl -OJ https://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip
     unzip -qq xmlsectool-2.0.0-bin.zip
     rm -f xmlsectool-2.0.0-bin.zip
     echo -e "\n"

--- a/spidMetadataSigner.sh
+++ b/spidMetadataSigner.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e 
+
 echo -e "\n"
 echo "==============================================="
 echo "      AgID Agenzia per l'Italia Digitale       "


### PR DESCRIPTION
Uso https per scaricare il file da shibboleth, in modo che curl possa verificare la validità del certificato SSL ed evitare così attacchi di tipo man-in-the-middle e/o dns poisoning (nel caso in cui il certificato non sia valido il download fallisce e lo script si ferma grazie a "set -e")