### PR TITLE
Comando rimozione password da chiave

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ openssl req -x509 -sha256 -days 365 -newkey rsa:2048 -keyout nome-chiave.key -ou
 
 Per rimuovere la password alla chiave:
 ```
-openssl rsa -des3 -in your.key -out your.encrypted.key
+openssl rsa -in your.encrypted.key -out your.key
 ```
 
 Per aggiungere la password alla chiave:


### PR DESCRIPTION
Il comando per rimuovere la password mi chiedeva di inserirne un'altra, infatti era identico al comando per aggiungerla (probabilmente una svista)