### PR TITLE
Funzioni per un uso veloce e ripetuto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.config
+certs
+metadata
+xmlsectool-2.0.0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Per utilizzare lo script è necessario avere:
 * [XmlSecTool](http://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip) (scaricato e verificato automaticamente dallo script)
 * Java
 * Unzip
+* curl
 * Metadata compliant alle [Regole Tecniche SPID](http://spid-regole-tecniche.readthedocs.io/en/latest/)
 * Chiave e certificato di firma (va bene anche quello utilizzato per la firma delle asserzioni saml)
 
@@ -41,12 +42,16 @@ __Nota__: lo script effettua un controllo dei requisiti software e parametri
 ./spidMetadataSigner.sh
 ```
 
+I parametri seguenti possono essere inseriti in un file da cui leggere i valori predefiniti ad ogni esecuzione, un esempio è riportato in ```config.sample```.
+Il file di impostazioni deve essere chiamato ```.config```, nella directory principale del progetto.
+
+
 Verranno richiesti i seguenti parametri:
 
-* nome del metadata da firmare (senza estensione - es: .xml)
-* nome della chiave (con estensione - es: .key)
+* nome del metadata da firmare (con estensione - es: FederationMetadata.xml)
+* nome della chiave (con estensione - es: firmaspidkey)
 * password della chiave, se presente, altrimenti lasciare vuota
-* nome del certificato (con estensione - es: .crt)
+* nome del certificato (con estensione - es: firmaspid.crt)
 * JAVA_HOME (se non presente) lo script suggerirà il path
 
 Alla fine della procedura il metadata firmato sarà caricato nella cartella "metadata/metadata-out"

--- a/config.sample
+++ b/config.sample
@@ -1,0 +1,14 @@
+# Nome del file nella directory metadata/metadata-in/
+metadataFileName="FederationMetadata.xml"
+
+# Nome del file nella directory certs/
+keyName="spidproxy-plain.key"
+
+# passphrase della chiave se presente
+keyPass=""
+
+# Nome del file nella directory certs/
+crtName="spidproxy.crt"
+
+# Path della JAVA_HOME
+javaHome="/Library/Java/JavaVirtualMachines/jdk1.8.0_20.jdk/Contents/Home"

--- a/tools/adfs/README.md
+++ b/tools/adfs/README.md
@@ -1,0 +1,43 @@
+# Creazione di metadati SPID per SP basati su ADFS (Active Directory Federation Services)
+
+Active Directory Federation Services è un sistema di Web SSO che permette di realizzare l'adesione a SPID funzionando come *nodo cluster*, secondo la definizione dell'avviso n.6 delle norme tecniche SPID.
+
+Perché possa interfacciarsi correttamente con SPID è necessario un componente software custom che faccia da tramite tra gli IDP SPID e il nodo cluster.
+
+Lo script si occupa di scaricare e modificare automaticamente i metadati generati da un sistema ADFS, convertendoli nel formato richiesto dalle norme tecniche SPID e successivi avvisi.
+
+## Utilizzo
+
+Eseguire lo script dalla radice del progetto, specificando l'URL dove raggiungere ADFS:
+```
+bash tools/adfs/adfs2spid-sp.sh -u adfs.contoso.com
+```
+
+## Prerequisiti
+
+Nel sistema dove si esegue lo script è necessaria la presenza dei comandi `curl`, `openssl` e `xmllint`.
+
+## Operazioni effettuate
+
+- download dei metadati di ADFS e posizionamento nella directory per la firma con `spid-metadata-signer.sh`
+- cancellazione degli elementi non previsti dalle norme tecniche
+- inserimento di valori obbligatori
+- inserimento degli *AttributeConsumingService* da dichiare per definire le classi di servizio
+- sostituzione del certificato di signing di ADFS con quello usato per la firma dei metadati
+- validazione e formattazione del file XML risultante
+
+## Configurazione
+
+Il contenuto degli *AttributeConsumingService* è definito nel file ```classi-di-servizio.xml```. Deve contenere le classi di attributi previste dagli IDP SPID.
+
+
+## Riferimenti
+
+La modellazione dei metadati è basata sulle specifiche riportate nelle comunicazioni di Agid:
+
+* http://www.agid.gov.it/sites/default/files/circolari/spid-regole_tecniche_v1.pdf
+* http://www.agid.gov.it/sites/default/files/documentazione/spid-avviso-n6-note-sul-dispiegamento-di-spid-presso-i-gestori-di-servizi-v1.pdf
+* http://www.agid.gov.it/sites/default/files/regole_tecniche/spid_tabella_messaggi_di_anomalia_v1.0.pdf
+* http://www.agid.gov.it/sites/default/files/regole_tecniche/tabella_attributi_idp_v1_0.pdf
+
+e dalle risposte del servizio di HelpDesk per quanto non previsto nelle comunicazioni ufficiali.

--- a/tools/adfs/adfs2spid-sp.sh
+++ b/tools/adfs/adfs2spid-sp.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Author: Cristian Mezzetti <cristian.mezzetti@unibo.it>
+
+set -e
+
+if [ $# -ne 2 ] || [ "$1" -ne "-u" ] ; then
+    echo "Uso dello script: adfs2spid-sp.sh -u adfs.contoso.com"
+    exit 1
+fi
+
+adfsUrl="$2"
+
+if [ ! -x $(which curl) ]; then
+    echo "Comando curl non trovato, impossibile proseguire"
+    exit 1
+fi
+
+adfsMetadata="https://${adfsUrl}/FederationMetadata/2007-06/FederationMetadata.xml"
+metadataFile="$(basename $adfsMetadata)"
+metadataDir="metadata/metadata-in"
+certificate="certs/spidproxy.crt"
+classi=$(cat tools/adfs/classi-di-servizio.xml | tr -d '\n')
+
+curl -OJ "$adfsMetadata"
+mv $metadataFile $metadataDir/
+
+# ADFS ha già i metadati firmati, vanno cancellate le firme apposta prima della nuova firma
+sed -i 's/<ds:Signature.*<\/ds:Signature>//' "$metadataDir/$metadataFile"
+
+# Eliminazione dei metadati superflui per il ruolo di SP
+sed -i 's/<RoleDescriptor.*<\/RoleDescriptor>//' "$metadataDir/$metadataFile"
+sed -i 's/<IDPSSODescriptor.*<\/IDPSSODescriptor>//' "$metadataDir/$metadataFile"
+
+# Elementi non previsti dalle norme tecniche SPID
+sed -i 's/<ContactPerson.*<\/ContactPerson>//' "$metadataDir/$metadataFile"
+sed -i 's/<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress<\/NameIDFormat>//' "$metadataDir/$metadataFile"
+sed -i 's/<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent<\/NameIDFormat>//' "$metadataDir/$metadataFile"
+
+# AuthRequestsSigned="true" è richiesto dalle norme tecniche SPID
+sed -i 's/<SPSSODescriptor /<SPSSODescriptor AuthnRequestsSigned="true" /' "$metadataDir/$metadataFile"
+
+# Eliminato HTTP-Artifact non accettato del servizio tecnico Agid
+sed -i 's/<AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https:\/\/${adfsUrl}\/adfs\/ls\/" index="1"\/>//' "$metadataDir/$metadataFile"
+
+# Tipi di LogoutService non previsti dalle norme tecniche SPID
+sed -i 's/<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https:\/\/${adfsUrl}\/adfs\/ls\/"\/>//' "$metadataDir/$metadataFile"
+sed -i 's/<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https:\/\/${adfsUrl}\/adfs\/ls\/"\/>/<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https:\/\/$adfsUrl\/adfs\/ls\/singleLogoutService"\/>/' "$metadataDir/$metadataFile"
+
+# Sostituzione certificato originale con quello di signing ad hoc
+tmp_cert=$(openssl x509 -in $certificate -text | tr -d ' ' | tr -d '\n')
+signing_cert=$(echo $tmp_cert | sed -e 's/^.*BEGINCERTIFICATE-----//' | sed -e 's/-----ENDCERTIFICATE-----$//')
+sed -i "s@\(.KeyDescriptor.use..signing.*.<X509Certificate>\).*\(<\/X509Certificate\)@\1$signing_cert\2@" "$metadataDir/$metadataFile"
+
+# inserimento del contenuto degli AssertionConsumingService richiesti
+cat "$metadataDir/$metadataFile" | sed -e "s@</SPSSODescriptor>@$classi</SPSSODescriptor>@" > tmp.xml
+
+xmllint --format tmp.xml > "$metadataDir/$metadataFile" && rm tmp.xml

--- a/tools/adfs/classi-di-servizio.xml
+++ b/tools/adfs/classi-di-servizio.xml
@@ -1,0 +1,46 @@
+<AttributeConsumingService index="0">
+      <ServiceName xml:lang="it">SetMinimum</ServiceName>
+      <ServiceDescription xml:lang="it">Attributi servizio minimi</ServiceDescription>
+      <RequestedAttribute Name="spidCode" />
+      <RequestedAttribute Name="familyName" />
+      <RequestedAttribute Name="name" />
+      <RequestedAttribute Name="gender" />
+      <RequestedAttribute Name="email" />
+      <RequestedAttribute Name="fiscalNumber" />
+</AttributeConsumingService>
+<AttributeConsumingService index="1">
+      <ServiceName xml:lang="it">SetMedium</ServiceName>
+      <ServiceDescription xml:lang="it">Attributi servizio medi</ServiceDescription>
+      <RequestedAttribute Name="spidCode" />
+      <RequestedAttribute Name="familyName" />
+      <RequestedAttribute Name="name" />
+      <RequestedAttribute Name="fiscalNumber" />
+      <RequestedAttribute Name="gender" />
+      <RequestedAttribute Name="companyName" />
+      <RequestedAttribute Name="registeredOffice" />
+      <RequestedAttribute Name="ivaCode" />
+      <RequestedAttribute Name="idCard" />
+      <RequestedAttribute Name="expirationDate" />
+      <RequestedAttribute Name="email" />
+      <RequestedAttribute Name="digitalAddress" />
+</AttributeConsumingService>
+<AttributeConsumingService index="2">
+      <ServiceName xml:lang="it">SetFull</ServiceName>
+      <ServiceDescription xml:lang="it">Attributi servizio totali</ServiceDescription>
+      <RequestedAttribute Name="spidCode" />
+      <RequestedAttribute Name="familyName" />
+      <RequestedAttribute Name="name" />
+      <RequestedAttribute Name="fiscalNumber" />
+      <RequestedAttribute Name="gender" />
+      <RequestedAttribute Name="dateOfBirth" />
+      <RequestedAttribute Name="placeOfBirth" />
+      <RequestedAttribute Name="countyOfBirth" />
+      <RequestedAttribute Name="companyName" />
+      <RequestedAttribute Name="registeredOffice" />
+      <RequestedAttribute Name="ivaCode" />
+      <RequestedAttribute Name="idCard" />
+      <RequestedAttribute Name="mobilePhone" />
+      <RequestedAttribute Name="email" />
+      <RequestedAttribute Name="address" />
+      <RequestedAttribute Name="digitalAddress" />
+</AttributeConsumingService>


### PR DESCRIPTION
Durante il processo di approvazione dei metadati mi sono trovato a lanciare diverse volte lo script, ho effettuato in po' di modifiche per rendere più veloce l'interazione:

- Aggiunto file .gitignore per evitare commit su directory con contenuti sensibili
- Aggiunto il supporto per file di configurazione con i valori di default per la firma
- Aggiornata documentazione
- Aggiunto file di impostazioni d'esempio
- Inseriti controlli sui valori inseriti manualmente per interrompere l'esecuzione subito nel caso di dati sbagliati