### PR TITLE
Fix XmlSecTool download path

### DIFF
--- a/spidMetadataSigner.sh
+++ b/spidMetadataSigner.sh
@@ -76,7 +76,7 @@ echo -e "\n"
 # Download e installazione XmlSecTool 2.0.0
 if [ ! -d "xmlsectool-2.0.0" ]; then
     echo "Scaricamento XmlSecTool 2.0.0:"
-    curl -OJ https://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip
+    curl -OJ https://shibboleth.net/downloads/tools/xmlsectool/2.0.0/xmlsectool-2.0.0-bin.zip
     unzip -qq xmlsectool-2.0.0-bin.zip
     rm -f xmlsectool-2.0.0-bin.zip
     echo -e "\n"


### PR DESCRIPTION
As 2.0.0 is no longer the latest version, the URL was broken. I fixed it so that it still uses 2.0.0.