### PR TITLE
Specify certificate lifespan in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Per creare una chiave (con password) e un certificato:
 openssl req -x509 -sha256 -days 365 -newkey rsa:2048 -keyout nome-chiave.key -out nome-certificato.crt
 ```
 
+Nota bene: un certificato generato con questo comando avrà durata di 1 anno
+
 Per rimuovere la password alla chiave:
 ```
 openssl rsa -in your.encrypted.key -out your.key


### PR DESCRIPTION
adds certificate lifespan after command to generate it since it's never explicitly defined