### PR TITLE
Indicazione più precisa dei requisiti Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lo script permette di firmare un metadata SAML utilizzando [XmlSecTool](http://s
 Per utilizzare lo script è necessario avere:
 
 * [XmlSecTool](http://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip) (scaricato e verificato automaticamente dallo script)
-* Java
+* Java Development Kit
 * Unzip
 * curl
 * Metadata compliant alle [Regole Tecniche SPID](http://spid-regole-tecniche.readthedocs.io/en/latest/)


### PR DESCRIPTION
Nel file spidMetadataSigner.sh alla linea 75 viene testata la presenza della cartella Java (creata sia in caso di installazione di JRE che di JDK), mentre alla linea 96 viene espressamente richiesto la presenza del compilatore Java (javac), che è presente solo in caso di installazione del JDK.

La pull request risolve l'ambiguità, indicando come requisito l'installazione del JDK